### PR TITLE
point get_subscription_products_info back at original hyp3 v1 API url

### DIFF
--- a/ASF/GEOS_657_Labs/asf_notebook.py
+++ b/ASF/GEOS_657_Labs/asf_notebook.py
@@ -346,7 +346,6 @@ def get_subscription_products_info(subscription_id: int, login: EarthdataLogin, 
     assert type(subscription_id) == str, f'Error: subscription_id must be a string, not a {type(subscription_id)}'                      
     assert type(login) == EarthdataLogin, f'Error: login must be an EarthdataLogin object, not a {type(login)}'               
 
-    login.api.url = "http://hyp3-api-prod.us-east-1.elasticbeanstalk.com/"
     products = []
     page_count = 0
     while True:       

--- a/ASF/Projects/asf_notebook.py
+++ b/ASF/Projects/asf_notebook.py
@@ -346,7 +346,6 @@ def get_subscription_products_info(subscription_id: int, login: EarthdataLogin, 
     assert type(subscription_id) == str, f'Error: subscription_id must be a string, not a {type(subscription_id)}'                      
     assert type(login) == EarthdataLogin, f'Error: login must be an EarthdataLogin object, not a {type(login)}'               
 
-    login.api.url = "http://hyp3-api-prod.us-east-1.elasticbeanstalk.com/"
     products = []
     page_count = 0
     while True:       

--- a/SAR_Training/English/Ecosystems/asf_notebook.py
+++ b/SAR_Training/English/Ecosystems/asf_notebook.py
@@ -346,7 +346,6 @@ def get_subscription_products_info(subscription_id: int, login: EarthdataLogin, 
     assert type(subscription_id) == str, f'Error: subscription_id must be a string, not a {type(subscription_id)}'                      
     assert type(login) == EarthdataLogin, f'Error: login must be an EarthdataLogin object, not a {type(login)}'               
 
-    login.api.url = "http://hyp3-api-prod.us-east-1.elasticbeanstalk.com/"
     products = []
     page_count = 0
     while True:       

--- a/SAR_Training/English/Hazards/asf_notebook.py
+++ b/SAR_Training/English/Hazards/asf_notebook.py
@@ -346,7 +346,6 @@ def get_subscription_products_info(subscription_id: int, login: EarthdataLogin, 
     assert type(subscription_id) == str, f'Error: subscription_id must be a string, not a {type(subscription_id)}'                      
     assert type(login) == EarthdataLogin, f'Error: login must be an EarthdataLogin object, not a {type(login)}'               
 
-    login.api.url = "http://hyp3-api-prod.us-east-1.elasticbeanstalk.com/"
     products = []
     page_count = 0
     while True:       

--- a/SAR_Training/English/Master/asf_notebook.py
+++ b/SAR_Training/English/Master/asf_notebook.py
@@ -346,7 +346,6 @@ def get_subscription_products_info(subscription_id: int, login: EarthdataLogin, 
     assert type(subscription_id) == str, f'Error: subscription_id must be a string, not a {type(subscription_id)}'                      
     assert type(login) == EarthdataLogin, f'Error: login must be an EarthdataLogin object, not a {type(login)}'               
 
-    login.api.url = "http://hyp3-api-prod.us-east-1.elasticbeanstalk.com/"
     products = []
     page_count = 0
     while True:       


### PR DESCRIPTION
We had temporarily pointed the API to the temporary student version of the API for asf_notebook.get_subscription_products_info. This reverts that temporary change.