### PR TITLE
drop try/except on hyp3_sdk import, always upgrade hyp3-sdk

### DIFF
--- a/ASF/Projects/Prepare_RTC_Stack_HyP3_v2.ipynb
+++ b/ASF/Projects/Prepare_RTC_Stack_HyP3_v2.ipynb
@@ -64,11 +64,8 @@
     "\n",
     "import asf_notebook as asfn\n",
     "\n",
-    "try:\n",
-    "    from hyp3_sdk import Batch\n",
-    "except:\n",
-    "    !python -m pip install hyp3-sdk==0.5 --user\n",
-    "    from hyp3_sdk import Batch"
+    "!python -m pip install hyp3-sdk --upgrade\n",
+    "from hyp3_sdk import Batch"
    ]
   },
   {

--- a/ASF/Projects/Prepare_RTC_Stack_HyP3_v2.ipynb
+++ b/ASF/Projects/Prepare_RTC_Stack_HyP3_v2.ipynb
@@ -64,7 +64,7 @@
     "\n",
     "import asf_notebook as asfn\n",
     "\n",
-    "!python -m pip install hyp3-sdk --upgrade\n",
+    "!python -m pip install hyp3-sdk~=1.0 --upgrade\n",
     "from hyp3_sdk import Batch"
    ]
   },
@@ -850,7 +850,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,

--- a/SAR_Training/English/Hazards/Prepare_RTC_Stack_HyP3_v2.ipynb
+++ b/SAR_Training/English/Hazards/Prepare_RTC_Stack_HyP3_v2.ipynb
@@ -64,11 +64,8 @@
     "\n",
     "import asf_notebook as asfn\n",
     "\n",
-    "try:\n",
-    "    from hyp3_sdk import Batch\n",
-    "except:\n",
-    "    !python -m pip install hyp3-sdk==0.5 --user\n",
-    "    from hyp3_sdk import Batch"
+    "!python -m pip install hyp3-sdk --upgrade\n",
+    "from hyp3_sdk import Batch"
    ]
   },
   {

--- a/SAR_Training/English/Hazards/Prepare_RTC_Stack_HyP3_v2.ipynb
+++ b/SAR_Training/English/Hazards/Prepare_RTC_Stack_HyP3_v2.ipynb
@@ -64,7 +64,7 @@
     "\n",
     "import asf_notebook as asfn\n",
     "\n",
-    "!python -m pip install hyp3-sdk --upgrade\n",
+    "!python -m pip install hyp3-sdk~=1.0 --upgrade\n",
     "from hyp3_sdk import Batch"
    ]
   },
@@ -850,7 +850,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,

--- a/SAR_Training/English/Master/Prepare_RTC_Stack_HyP3_v2.ipynb
+++ b/SAR_Training/English/Master/Prepare_RTC_Stack_HyP3_v2.ipynb
@@ -64,11 +64,8 @@
     "\n",
     "import asf_notebook as asfn\n",
     "\n",
-    "try:\n",
-    "    from hyp3_sdk import Batch\n",
-    "except:\n",
-    "    !python -m pip install hyp3-sdk==0.5 --user\n",
-    "    from hyp3_sdk import Batch"
+    "!python -m pip install hyp3-sdk --upgrade\n",
+    "from hyp3_sdk import Batch"
    ]
   },
   {

--- a/SAR_Training/English/Master/Prepare_RTC_Stack_HyP3_v2.ipynb
+++ b/SAR_Training/English/Master/Prepare_RTC_Stack_HyP3_v2.ipynb
@@ -64,7 +64,7 @@
     "\n",
     "import asf_notebook as asfn\n",
     "\n",
-    "!python -m pip install hyp3-sdk --upgrade\n",
+    "!python -m pip install hyp3-sdk~=1.0 --upgrade\n",
     "from hyp3_sdk import Batch"
    ]
   },
@@ -850,7 +850,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Users were ending up with outdated hyp3-sdk versions that break the notebook. Now defaulting to always installing or upgrading latest version.